### PR TITLE
feat: Support show/hide from the appindicator icon

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,16 @@ function createWindow () {
   });
 
   tray = new Tray(icon);
+  // Ignore double click events for the tray icon
+  tray.setIgnoreDoubleClickEvents(true)
+  tray.on('click', () => {
+    console.log("AppIndicator clicked");
+    if (win.isVisible()) {
+      win.hide();
+    } else {
+      win.show();
+    }
+  });
 
   const contextMenu = Menu.buildFromTemplate([
     {


### PR DESCRIPTION
feat: Support show/hide from the appindicator icon, not just the tray menu.

This doesn't work in GNOME, but does in KDE. Fixes #5